### PR TITLE
Improved sidebar initialization time and rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "build": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint",
     "format": "prettier --config .prettierrc --write */**/*.*",
-    "dev": "concurrently --kill-others \"vue-cli-service build --watch --mode development\" \"npx vue-devtools\"",
-    "stage": "concurrently --kill-others \"vue-cli-service build --watch --mode staging\" \"npx vue-devtools\""
+    "dev": "vue-cli-service build --watch --mode development",
+    "dev devtools": "concurrently --kill-others \"vue-cli-service build --watch --mode development\" \"npx vue-devtools\"",
+    "stage": "vue-cli-service build --watch --mode staging",
+    "stage devtools": "concurrently --kill-others \"vue-cli-service build --watch --mode staging\" \"npx vue-devtools\""
   },
   "dependencies": {
     "@types/lodash-es": "^4.17.3",

--- a/src/sidebar/main.ts
+++ b/src/sidebar/main.ts
@@ -27,14 +27,10 @@ export class JellyPartyController {
     if (document.querySelector(this.provider.awaitCSSSelector) === null) {
       console.log(`Jelly-Party: Waiting for ${this.provider.awaitCSSSelector}`);
       setTimeout(() => {
-        // Check again in 1 second if we can find the required DOM element
         this.waitForHTMLElementThenInit();
-      }, 1000);
+      }, 100);
     } else {
-      // Wait for 1 second, then attach sidebar
-      setTimeout(() => {
-        this.sidebar.attachSidebarToDOM();
-      }, 1000);
+      this.sidebar.attachSidebarToDOM();
     }
   }
 

--- a/src/sidebar/provider/providers/Customizer.ts
+++ b/src/sidebar/provider/providers/Customizer.ts
@@ -9,10 +9,7 @@ export abstract class Customizer {
     window.addEventListener("fullscreenchange", debouncedAdjustView);
     window.addEventListener("resize", debouncedAdjustView);
     this.initNotyfFullscreenHandler();
-    // Update view shortly after initialization
-    setTimeout(() => {
-      this.adjustView.bind(this);
-    }, 3000);
+    this.adjustForNoFullscreenAndSidebar();
   }
 
   querySelector(selector: string) {

--- a/src/sidebar/provider/providers/youtube/YouTubeCustomizer.ts
+++ b/src/sidebar/provider/providers/youtube/YouTubeCustomizer.ts
@@ -36,22 +36,20 @@ export class YouTubeCustomizer extends Customizer {
   }
 
   adjustForNoFullscreenAndSidebar() {
-    setTimeout(() => {
-      if (
-        this.containerTarget &&
-        this.videoTarget &&
-        this.controlsTarget &&
-        this.playerTarget
-      ) {
-        this.containerTarget.style.width =
-          "calc(100vw - var(--jelly-party-sidebar-width))";
-        const playerWidth = this.playerTarget.offsetWidth;
-        const playerHeight = this.playerTarget.offsetHeight;
-        this.videoTarget.style.width = `${playerWidth}px`;
-        this.videoTarget.style.height = `${playerHeight}px`;
-        this.controlsTarget.style.width = `${playerWidth - 30}px`;
-      }
-    }, 1000);
+    if (
+      this.containerTarget &&
+      this.videoTarget &&
+      this.controlsTarget &&
+      this.playerTarget
+    ) {
+      this.containerTarget.style.width =
+        "calc(100vw - var(--jelly-party-sidebar-width))";
+      const playerWidth = this.playerTarget.offsetWidth;
+      const playerHeight = this.playerTarget.offsetHeight;
+      this.videoTarget.style.width = `${playerWidth}px`;
+      this.videoTarget.style.height = `${playerHeight}px`;
+      this.controlsTarget.style.width = `${playerWidth - 30}px`;
+    }
   }
 
   adjustForNoFullscreenAndNoSidebar() {


### PR DESCRIPTION
Make Jelly-Party snappier by removing unnecessary `setTimeout`s and reducing `setTimeout` times.