### PR TITLE
Define empty `amazon` in `tests/config.template.ts`

### DIFF
--- a/tests/config.template.ts
+++ b/tests/config.template.ts
@@ -3,6 +3,7 @@ export const config = {
   ublockPath:
     "/home/user/.config/google-chrome/Profile 1/Extensions/cjpalhdlnbpafiamejdnhcphjbkeiagm/1.28.4_0",
   cookies: {
+    amazon: [],
     netflix: [],
     disneyPlus: [],
   },


### PR DESCRIPTION
Before this change `config.ts` created out of `config.template.ts` printed
following error on run:

    ERROR in [snip]/tests/src/index.ts(46,29):
    46:29 Property 'amazon' does not exist on type '{ netflix: never[]; disneyPlus: never[]; }'.
        44 |       "https://join.jelly-party.com/?redirectURL=https%253A%252F%252Fwww.amazon.de%252FAmazon-Video%252Fb%252F%253Fnode%253D3010075031%2526ref%253Ddvm_MLP_ROWEU_DE_1&jellyPartyId=incredible-satisfactions-explode-maybe",
        45 |     setCookiesAtURL: "https://www.amazon.de",
      > 46 |     cookies: config.cookies.amazon,
           |                             ^
        47 |   },
        48 | };
        49 |