### PR TITLE
Fix README how to run stage with devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains all code for the browser extension [Jelly-Party](https://chro
 
 ```
 npm install
-npm run stage
+npm run 'stage devtools'
 ```
 
 This will compile the project and serve it under `dist`, which you can load unpacked into Chrome or Firefox. Furthermore, this spins up `vue-remote-devtools` for debugging purposes.


### PR DESCRIPTION
Before this change `npm run` command in README didn't spin up
`vue-remote-devtools` even though its description later in the text said
so.